### PR TITLE
[UPDATE] standardize dp_deploy_goblet.yml version. 2.0->1.1.0

### DIFF
--- a/.github/workflows/Test_2.yml
+++ b/.github/workflows/Test_2.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
     Deploy:
-      uses: premisedata/commons-github-actions/.github/workflows/dp_deploy_goblet.yml@2.0
+      uses: premisedata/commons-github-actions/.github/workflows/dp_deploy_goblet.yml@1.1.0


### PR DESCRIPTION
PLEASE APPROVE BUT DON'T MERGE UNTIL common-github-actions version 1.1.0 release
We are standardizing usage of dp_deploy_goblet versioning.

Any workflow using dp_deploy_goblet.yml@2.0 must point to 1.1.0

More info:
https://premisedata.atlassian.net/browse/INFRA-1469